### PR TITLE
Fixed a couple of bugs to train the LDM part of the model

### DIFF
--- a/LDM/ldm/models/diffusion/ddpm.py
+++ b/LDM/ldm/models/diffusion/ddpm.py
@@ -939,7 +939,7 @@ class LatentDiffusion(DDPM):
         loss_simple = self.get_loss(model_output, target, mean=False).mean([1, 2, 3])
         loss_dict.update({f'{prefix}/loss_simple': loss_simple.mean()})
 
-        logvar_t = self.logvar[t].to(self.device)
+        logvar_t = self.logvar[t.cpu()].to(self.device)
         logvar_t = repeat(logvar_t, 'b -> b c', c=loss_simple.shape[1])
         loss = loss_simple / torch.exp(logvar_t) + logvar_t
         # loss = loss_simple / torch.exp(self.logvar) + self.logvar

--- a/LDM/ldm/models/normalization.py
+++ b/LDM/ldm/models/normalization.py
@@ -15,7 +15,7 @@ class SPADE(nn.Module):
                              % norm_type)
 
         # The dimension of the intermediate embedding space. Yes, hardcoded.
-        nhidden = 128
+        nhidden = 64
 
         pw = kernel_size // 2
         self.mlp_shared = nn.Sequential(
@@ -94,7 +94,7 @@ class SPADEResnetBlock(nn.Module):
 class SPADEGenerator(nn.Module):
     def __init__(self,modalities, z_dim=3):
         super().__init__()
-        nf = 128
+        nf = 64
         self.in_spade = SPADEResnetBlock(modalities, z_dim, nf)
         self.out_spade = SPADEResnetBlock(modalities, nf, z_dim)
 


### PR DESCRIPTION
Hi,
Thank you so much for the code!!The following changes are required to train the LMD model.

The following were hardcoded in LDM's `normalization.py`:
`nhidden = 128`
`nf = 128`

Changed them to 
`nhidden = 64`
`nf = 64`

so that the trained VQ-GAN can be used to initialize the LDM model.

In `ddpm.py`,
change `logvar_t = self.logvar[t].to(self.device)` to `logvar_t = self.logvar[t.cpu()].to(self.device)`.
